### PR TITLE
implemented all the edit message functions

### DIFF
--- a/bot.go
+++ b/bot.go
@@ -130,6 +130,28 @@ type Bot interface {
 	// SetChatAdministratorCustomTitle is used to set a custom title for an administrator
 	// in a supergroup promoted by the bot.
 	SetChatAdministratorCustomTitle(title envelop.SetChatAdministratorCustomTitle) (bool, error)
+	// EditMessageText is used to edit text and game messages.
+	EditMessageText(msg envelop.EditMessageTextEnvelop) (entity.Message, error)
+	// EditMessageCaption is used to edit captions of messages.
+	EditMessageCaption(msg envelop.EditMessageCaptionEnvelop) (entity.Message, error)
+	// EditMessageMedia is used to edit animation, audio, document, photo, or video messages.
+	EditMessageMedia(msg envelop.EditMessageMediaEnvelop) (entity.Message, error)
+	// EditMessageLiveLocation is used to edit live location messages.
+	EditMessageLiveLocation(msg envelop.EditMessageLiveLocationEnvelop) (entity.Message, error)
+	// StopMessageLiveLocation is used to stop updating a live location message before live_period expires.
+	StopMessageLiveLocation(msg envelop.StopMessageLiveLocationEnvelop) (entity.Message, error)
+	// EditMessageReplyMarkup is used to edit only the reply markup of messages.
+	EditMessageReplyMarkup(msg envelop.EditMessageReplyMarkupEnvelop) (entity.Message, error)
+	// StopPoll is used to stop a poll which was sent by the bot.
+	StopPoll(msg envelop.StopPollEnvelop) (entity.Poll, error)
+	// DeleteMessage is used to delete a message, including service messages, with the following limitations:
+	// - A message can only be deleted if it was sent less than 48 hours ago.
+	// - Bots can delete outgoing messages in private chats, groups, and supergroups.
+	// - Bots can delete incoming messages in private chats.
+	// - Bots granted can_post_messages permissions can delete outgoing messages in channels.
+	// - If the bot is an administrator of a group, it can delete any message there.
+	// - If the bot has can_delete_messages permission in a supergroup or a channel, it can delete any message there.
+	DeleteMessage(msg envelop.DeleteMessageEnvelop) (bool, error)
 }
 
 // BotOptions hold the options for the bot

--- a/default.go
+++ b/default.go
@@ -252,3 +252,107 @@ func (b *bot) SetChatAdministratorCustomTitle(title envelop.SetChatAdministrator
 
 	return status, json.Unmarshal(res, &status)
 }
+
+func (b *bot) EditMessageText(msg envelop.EditMessageTextEnvelop) (entity.Message, error) {
+	res, err := b.SendRawRequest(http.MethodPost, "editMessageText", func() (io.Reader, BodyOptions, error) {
+		return GetJSONBody(msg)
+	}, SetApplicationJSON)
+	if err != nil {
+		return entity.Message{}, err
+	}
+
+	var message entity.Message
+
+	return message, json.Unmarshal(res, &message)
+}
+
+func (b *bot) EditMessageCaption(msg envelop.EditMessageCaptionEnvelop) (entity.Message, error) {
+	res, err := b.SendRawRequest(http.MethodPost, "editMessageCaption", func() (io.Reader, BodyOptions, error) {
+		return GetJSONBody(msg)
+	}, SetApplicationJSON)
+	if err != nil {
+		return entity.Message{}, err
+	}
+
+	var message entity.Message
+
+	return message, json.Unmarshal(res, &message)
+}
+
+func (b *bot) EditMessageMedia(msg envelop.EditMessageMediaEnvelop) (entity.Message, error) {
+	res, err := b.SendRawRequest(http.MethodPost, "editMessageMedia", func() (io.Reader, BodyOptions, error) {
+		return GetJSONBody(msg)
+	}, SetApplicationJSON)
+	if err != nil {
+		return entity.Message{}, err
+	}
+
+	var message entity.Message
+
+	return message, json.Unmarshal(res, &message)
+}
+
+func (b *bot) EditMessageLiveLocation(msg envelop.EditMessageLiveLocationEnvelop) (entity.Message, error) {
+	res, err := b.SendRawRequest(http.MethodPost, "editMessageLiveLocation", func() (io.Reader, BodyOptions, error) {
+		return GetJSONBody(msg)
+	}, SetApplicationJSON)
+	if err != nil {
+		return entity.Message{}, err
+	}
+
+	var message entity.Message
+
+	return message, json.Unmarshal(res, &message)
+}
+
+func (b *bot) StopMessageLiveLocation(msg envelop.StopMessageLiveLocationEnvelop) (entity.Message, error) {
+	res, err := b.SendRawRequest(http.MethodPost, "stopMessageLiveLocation", func() (io.Reader, BodyOptions, error) {
+		return GetJSONBody(msg)
+	}, SetApplicationJSON)
+	if err != nil {
+		return entity.Message{}, err
+	}
+
+	var message entity.Message
+
+	return message, json.Unmarshal(res, &message)
+}
+
+func (b *bot) EditMessageReplyMarkup(msg envelop.EditMessageReplyMarkupEnvelop) (entity.Message, error) {
+	res, err := b.SendRawRequest(http.MethodPost, "editMessageReplyMarkup", func() (io.Reader, BodyOptions, error) {
+		return GetJSONBody(msg)
+	}, SetApplicationJSON)
+	if err != nil {
+		return entity.Message{}, err
+	}
+
+	var message entity.Message
+
+	return message, json.Unmarshal(res, &message)
+}
+
+func (b *bot) StopPoll(msg envelop.StopPollEnvelop) (entity.Poll, error) {
+	res, err := b.SendRawRequest(http.MethodPost, "stopPoll", func() (io.Reader, BodyOptions, error) {
+		return GetJSONBody(msg)
+	}, SetApplicationJSON)
+	if err != nil {
+		return entity.Poll{}, err
+	}
+
+	var poll entity.Poll
+
+	return poll, json.Unmarshal(res, &poll)
+}
+
+func (b *bot) DeleteMessage(msg envelop.DeleteMessageEnvelop) (bool, error) {
+	res, err := b.SendRawRequest(http.MethodPost, "deleteMessage", func() (io.Reader, BodyOptions, error) {
+		return GetJSONBody(msg)
+	}, SetApplicationJSON)
+	if err != nil {
+		return false, err
+	}
+
+	var status bool
+
+	return status, json.Unmarshal(res, &status)
+}

--- a/envelop/message.go
+++ b/envelop/message.go
@@ -68,3 +68,176 @@ type CopyMessageEnvelop struct {
 	// ReplyMarkup as an additional interface options.
 	ReplyMarkup entity.ReplyMarkup `json:"reply_markup,omitempty"`
 }
+
+// EditMessageTextEnvelop is used to edit text and game messages.
+type EditMessageTextEnvelop struct {
+	// ChatID is the id for the target chat or username.
+	//
+	// It is required if inline_message_id is not specified.
+	ChatID string `json:"chat_id,omitempty"`
+	// MessageID is the id of the message to edit.
+	//
+	// It is required if inline_message_id is not specified.
+	MessageID int64 `json:"message_id,omitempty"`
+	//InlineMessageID is the id of the inline message to edit.
+	//
+	// It is required if chat_id and message_id are not specified.
+	InlineMessageID string `json:"inline_message_id,omitempty"`
+	// Text is the new text of the message.
+	//
+	// It is a required field.
+	Text string `json:"text,omitempty"`
+	// ParseMode is mode for parsing entities in the message text.
+	ParseMode string `json:"parse_mode,omitempty"`
+	// Entities is a JSON-serialized list of special entities
+	// that appear in the message text,
+	// which can be specified instead of parse_mode.
+	Entities []entity.MessageEntity `json:"entities,omitempty"`
+	// DisableWebPagePreview is to disable link previews for links in the sent message.
+	DisableWebPagePreview bool `json:"disable_web_page_preview,omitempty"`
+	// ReplyMarkup as an additional interface options.
+	ReplyMarkup entity.InlineKeyboardMarkup `json:"reply_markup,omitempty"`
+}
+
+// EditMessageCaptionEnvelop is used to edit captions of messages.
+type EditMessageCaptionEnvelop struct {
+	// ChatID is the id for the target chat or username.
+	//
+	// It is required if inline_message_id is not specified.
+	ChatID string `json:"chat_id,omitempty"`
+	// MessageID is the id of the message to edit.
+	//
+	// It is required if inline_message_id is not specified.
+	MessageID int64 `json:"message_id,omitempty"`
+	//InlineMessageID is the id of the inline message to edit.
+	//
+	// It is required if chat_id and message_id are not specified.
+	InlineMessageID string `json:"inline_message_id,omitempty"`
+	// Caption is the new caption of the message.
+	Caption string `json:"caption,omitempty"`
+	// ParseMode is mode for parsing entities in the message text.
+	ParseMode string `json:"parse_mode,omitempty"`
+	// CaptionEntities is a JSON-serialized list of special entities
+	// that appear in the message text,
+	// which can be specified instead of parse_mode.
+	CaptionEntities []entity.MessageEntity `json:"caption_entities,omitempty"`
+	// ReplyMarkup as an additional interface options.
+	ReplyMarkup entity.InlineKeyboardMarkup `json:"reply_markup,omitempty"`
+}
+
+// EditMessageMediaEnvelop is used to edit animation, audio, document, photo, or video messages.
+type EditMessageMediaEnvelop struct {
+	// ChatID is the id for the target chat or username.
+	//
+	// It is required if inline_message_id is not specified.
+	ChatID string `json:"chat_id,omitempty"`
+	// MessageID is the id of the message to edit.
+	//
+	// It is required if inline_message_id is not specified.
+	MessageID int64 `json:"message_id,omitempty"`
+	//InlineMessageID is the id of the inline message to edit.
+	//
+	// It is required if chat_id and message_id are not specified.
+	InlineMessageID string `json:"inline_message_id,omitempty"`
+	// Media is a JSON-serialized object for a new media content of the message.
+	//
+	// It is a required field.
+	Media entity.InputMedia `json:"media,omitempty"`
+	// ReplyMarkup as an additional interface options.
+	ReplyMarkup entity.InlineKeyboardMarkup `json:"reply_markup,omitempty"`
+}
+
+// EditMessageLiveLocationEnvelop is used to edit live location messages.
+type EditMessageLiveLocationEnvelop struct {
+	// ChatID is the id for the target chat or username.
+	//
+	// It is required if inline_message_id is not specified.
+	ChatID string `json:"chat_id,omitempty"`
+	// MessageID is the id of the message to edit.
+	//
+	// It is required if inline_message_id is not specified.
+	MessageID int64 `json:"message_id,omitempty"`
+	//InlineMessageID is the id of the inline message to edit.
+	//
+	// It is required if chat_id and message_id are not specified.
+	InlineMessageID string `json:"inline_message_id,omitempty"`
+	// Latitude is the new latitude of the message.
+	//
+	// It is a required field.
+	Latitude float64 `json:"latitude,omitempty"`
+	// Longitude is the new longitude of the message.
+	//
+	// It is a required field.
+	Longitude float64 `json:"longitude,omitempty"`
+	// HorizontalAccuracy is the new horizontal accuracy of the message.
+	HorizontalAccuracy float64 `json:"horizontal_accuracy,omitempty"`
+	// Heading is the new direction in which the user is moving, in degrees.
+	Heading int64 `json:"heading,omitempty"`
+	// ProximityAlertRadius is the new maximum distance for proximity alerts
+	// about approaching another chat member, in meters.
+	ProximityAlertRadius int64 `json:"proximity_alert_radius,omitempty"`
+	// ReplyMarkup as an additional interface options.
+	ReplyMarkup entity.InlineKeyboardMarkup `json:"reply_markup,omitempty"`
+}
+
+// StopMessageLiveLocationEnvelop is used to stop updating a live location message.
+type StopMessageLiveLocationEnvelop struct {
+	// ChatID is the id for the target chat or username.
+	//
+	// It is required if inline_message_id is not specified.
+	ChatID string `json:"chat_id,omitempty"`
+	// MessageID is the id of the message to edit.
+	//
+	// It is required if inline_message_id is not specified.
+	MessageID int64 `json:"message_id,omitempty"`
+	//InlineMessageID is the id of the inline message to edit.
+	//
+	// It is required if chat_id and message_id are not specified.
+	InlineMessageID string `json:"inline_message_id,omitempty"`
+	// ReplyMarkup as an additional interface options.
+	ReplyMarkup entity.InlineKeyboardMarkup `json:"reply_markup,omitempty"`
+}
+
+// EditMessageReplyMarkupEnvelop is used to edit only the reply markup of messages.
+type EditMessageReplyMarkupEnvelop struct {
+	// ChatID is the id for the target chat or username.
+	//
+	// It is required if inline_message_id is not specified.
+	ChatID string `json:"chat_id,omitempty"`
+	// MessageID is the id of the message to edit.
+	//
+	// It is required if inline_message_id is not specified.
+	MessageID int64 `json:"message_id,omitempty"`
+	//InlineMessageID is the id of the inline message to edit.
+	//
+	// It is required if chat_id and message_id are not specified.
+	InlineMessageID string `json:"inline_message_id,omitempty"`
+	// ReplyMarkup as an additional interface options.
+	ReplyMarkup entity.InlineKeyboardMarkup `json:"reply_markup,omitempty"`
+}
+
+// StopPollEnvelop is used to stop a poll which was sent by the bot.
+type StopPollEnvelop struct {
+	// ChatID is the id for the target chat or username.
+	//
+	// It is required if inline_message_id is not specified.
+	ChatID string `json:"chat_id,omitempty"`
+	// MessageID is the id of the message to edit.
+	//
+	// It is required if inline_message_id is not specified.
+	MessageID int64 `json:"message_id,omitempty"`
+	// ReplyMarkup as an additional interface options.
+	ReplyMarkup entity.InlineKeyboardMarkup `json:"reply_markup,omitempty"`
+}
+
+// DeleteMessageEnvelop is used to delete a message, including service messages,
+type DeleteMessageEnvelop struct {
+	// ChatID is the id for the target chat or username.
+	//
+	// It is required if inline_message_id is not specified.
+	ChatID string `json:"chat_id,omitempty"`
+	// MessageID is the id of the message to edit.
+	//
+	// It is required if inline_message_id is not specified.
+	MessageID int64 `json:"message_id,omitempty"`
+}


### PR DESCRIPTION
I have created separate models and separate functions for each edit function to conform to #75.

A new issue is introduced though. these functions have different responses depending on the type of the message (inline or not). Since Go is statically typed, I am not sure how we should handle this at this moment. So instead of holding this issue I have created issue #76 to solve this.